### PR TITLE
fixes apb interface to capture correct i2s fifo

### DIFF
--- a/DE1_SOC_Linux_Audio/DE1_SOC_Linux_Audio.v
+++ b/DE1_SOC_Linux_Audio/DE1_SOC_Linux_Audio.v
@@ -428,7 +428,7 @@ module DE1_SOC_Linux_Audio(
 
 	// Mux capture data
 	assign i2s_output_apb_0_capture_fifo_data = i2s_clkctrl_apb_0_conduit_clk_sel_48_44 ?
-		i2s_capture_fifo_data48 : i2s_capture_fifo_data44;
+		i2s_capture_fifo_data44 : i2s_capture_fifo_data48;
 
 	// Mux out
 	assign AUD_DACDAT = i2s_clkctrl_apb_0_conduit_clk_sel_48_44 ? i2s_data_out44 : i2s_data_out48;


### PR DESCRIPTION
Hello Bjarne, 

I had an issue with the audio input stream. 
Turns out there was a swap in the input multiplexer so it chose the wrong data rate stream. 
This fixes it for me. 

Best wishes, 
Clemens